### PR TITLE
Fixing a bug in the watchdog thread for ./run_fusor_ui.py

### DIFF
--- a/rhci/scripts/run_fusor_ui.py
+++ b/rhci/scripts/run_fusor_ui.py
@@ -24,8 +24,9 @@ def keepalive_daemon():
     """
     while True:
         for vm_name in rhev_vms:
-            if virsh('domstate {}'.format(vm_name)) == 'shut off':
-                virsh('start {}'.format(vm_name))
+            if vm_name is not None:
+                if virsh('domstate {}'.format(vm_name)) == 'shut off':
+                    virsh('start {}'.format(vm_name))
         sleep(180)
 
 deployment = rhci['deployments'][rhci.deployment]['fusor']


### PR DESCRIPTION
This change ensures that the watchdog thread in run_fusor_ui will only check VMs that are defined in the rhci.yaml